### PR TITLE
socket智能指针赋值顺序修复

### DIFF
--- a/cppnet/socket/rw_socket.cpp
+++ b/cppnet/socket/rw_socket.cpp
@@ -139,8 +139,8 @@ void RWSocket::Connect(const std::string& ip, uint16_t port) {
     auto actions = GetEventActions();
     if (actions) {
         _connecting = true;
-        actions->AddConnection(_event, _addr);
         __connecting_socket_map[_sock] = shared_from_this();
+        actions->AddConnection(_event, _addr);
     }
 }
 


### PR DESCRIPTION
智能指针赋值需要在AddConnection之前，因为AddConnection函数里面可能会调用到OnConnect，而OnConnect里面有调用__connecting_socket_map的erase方法，导致删除失败。