### PR TITLE
修改了epoll_action部分在Windows平台下G++/GCC均報錯（雖然CL編譯成功）的析構判斷

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,4 +38,4 @@ add_subdirectory(cppnet)
 
 add_library(${PROJECT_NAME} STATIC ${common_source} ${cppnet_source})
 
-add_subdirectory(test)
+# add_subdirectory(test)

--- a/cppnet/event/epoll/epoll_action.cpp
+++ b/cppnet/event/epoll/epoll_action.cpp
@@ -50,10 +50,11 @@ EpollEventActions::EpollEventActions():
 }
 
 EpollEventActions::~EpollEventActions() {
-    if (_epoll_handler > 0) {
 #ifdef __win__
+    if (_epoll_handler != nullptr) {
         epoll_close(_epoll_handler);
 #else
+    if (_epoll_handler > 0) {
         close(_epoll_handler);
 #endif
     }


### PR DESCRIPTION
在make過程中出現error: ordered comparison of pointer with integer zero，推測錯誤為Windows代碼與Linux代碼在宏處理閒未完整分開