### PR TITLE
[FIX] add header + modify header

### DIFF
--- a/test/http/http_request.h
+++ b/test/http/http_request.h
@@ -1,7 +1,7 @@
 #ifndef TEST_HTTP_HTTP_REQUEST_HEADER
 #define TEST_HTTP_HTTP_REQUEST_HEADER
 
-#include <ctype.h>
+#include <cstdint>
 #include <string>
 #include <stdio.h>
 #include <assert.h>

--- a/test/http/http_response.h
+++ b/test/http/http_response.h
@@ -2,6 +2,7 @@
 #define TEST_HTTP_HTTP_RESPONSE_HEADER
 
 #include <map>
+#include <string>
 
 enum HttpStatusCode {
     kUnknown,


### PR DESCRIPTION
+ use `<cstdint>` instead of `<ctype.h>`
+ missing `<string>`, which `void SetStatusMessage(const std::string& message)` still use it