### PR TITLE
[ENH] code refine + fix compile warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ build/
 *.pro
 *.user
 *bug
+
+# compdb files
+.cache/
+compile_commands.json

--- a/common/buffer/buffer_interface.h
+++ b/common/buffer/buffer_interface.h
@@ -7,6 +7,7 @@
 #define COMMON_BUFFER_BUFFER_INTERFACE
 
 #include "include/cppnet_buffer.h"
+#include <memory>
 
 namespace cppnet {
 

--- a/common/log/base_logger.cpp
+++ b/common/log/base_logger.cpp
@@ -211,4 +211,4 @@ Log* BaseLogger::NewLog() {
     return item;
 }
 
-}
+} // namespace cppnet

--- a/common/log/file_logger.cpp
+++ b/common/log/file_logger.cpp
@@ -131,4 +131,4 @@ void FileLogger::CheckExpireFiles() {
     }
 }
 
-}
+} // namespace cppnet

--- a/common/log/file_logger.h
+++ b/common/log/file_logger.h
@@ -15,8 +15,6 @@
 
 namespace cppnet {
 
-static const uint8_t __file_logger_time_buf_size = sizeof("xxxx-xx-xx:xx");
-
 enum FileLoggerSpiltUnit {
     FLSU_DAY  = 1,
     FLSU_HOUR = 2,
@@ -54,6 +52,9 @@ private:
     void CheckExpireFiles();
 
 private:
+    enum : uint8_t {
+        __file_logger_time_buf_size = sizeof("xxxx-xx-xx:xx")
+    };
     std::string   _file_name;
     std::fstream  _stream;
 
@@ -68,6 +69,6 @@ private:
     std::queue<std::string> _history_file_names;
 };
 
-}
+} // namespace cppnet
 
 #endif

--- a/common/log/log.cpp
+++ b/common/log/log.cpp
@@ -65,4 +65,4 @@ LogStreamParam SingletonLogger::GetStreamParam(LogLevel level, const char* file,
     return _logger->GetStreamParam(level, file, line);
 }
 
-}
+} // namespace cppnet

--- a/common/log/log.h
+++ b/common/log/log.h
@@ -72,6 +72,6 @@ private:
     std::shared_ptr<BaseLogger> _logger;
 };
 
-}
+} // namespace cppnet
 
 #endif

--- a/common/log/log_stream.cpp
+++ b/common/log/log_stream.cpp
@@ -128,4 +128,4 @@ LogStream& LogStream::operator<<(char v) {
     return *this;
 }
 
-}
+} // namespace cppnet

--- a/common/log/log_stream.h
+++ b/common/log/log_stream.h
@@ -14,7 +14,8 @@
 namespace cppnet {
 
 struct Log;
-typedef std::pair<std::shared_ptr<Log>, std::function<void(std::shared_ptr<Log>)>> LogStreamParam;
+using LogStreamParam =
+    std::pair<std::shared_ptr<Log>, std::function<void(std::shared_ptr<Log>)>>;
 
 class LogStream {
 public:
@@ -47,6 +48,6 @@ private:
     std::function<void(std::shared_ptr<Log>)> _call_back;
 };
 
-}
+} // namespace cppnet
 
 #endif

--- a/common/log/logger_interface.h
+++ b/common/log/logger_interface.h
@@ -36,6 +36,6 @@ protected:
     std::shared_ptr<Logger> _logger;
 };
 
-}
+} // namespace cppnet
 
 #endif

--- a/common/log/stdout_logger.cpp
+++ b/common/log/stdout_logger.cpp
@@ -8,14 +8,6 @@
 
 namespace cppnet {
 
-StdoutLogger::StdoutLogger() {
-
-}
-
-StdoutLogger::~StdoutLogger() {
-
-}
-
 void StdoutLogger::Debug(std::shared_ptr<Log>& log) {
     {
         std::unique_lock<std::mutex> lock(_mutex);
@@ -56,4 +48,4 @@ void StdoutLogger::Fatal(std::shared_ptr<Log>& log) {
     Logger::Fatal(log);
 }
 
-}
+} // namespace cppnet

--- a/common/log/stdout_logger.h
+++ b/common/log/stdout_logger.h
@@ -15,8 +15,8 @@ class StdoutLogger:
     public Logger {
 
 public:
-    StdoutLogger();
-    ~StdoutLogger();
+    StdoutLogger() = default;
+    ~StdoutLogger() = default;
 
     void Debug(std::shared_ptr<Log>& log);
     void Info(std::shared_ptr<Log>& log);
@@ -28,6 +28,6 @@ private:
     std::mutex _mutex;
 };
 
-}
+} // namespace cppnet
 
 #endif


### PR DESCRIPTION
1. add compdb to gitignore
2. i dont know why i have some compile issues, `buffer_interface.h` use `sharded_ptr`, just add `<memory>` is ok
3. add LF to common/log/* end, this is for code style, and compiler compatity
4. in `file_logger.h`, expose`__file_logger_time_buf_size` to namespace cppnet, while i notice that it only used in class inside, use enum is better or static const uint8_t inside class
5. use cpp11 default for some smf