### PR TITLE
[MISC] Fix clang-tidy warning, use c++11 style, see below

### DIFF
--- a/common/util/random.h
+++ b/common/util/random.h
@@ -6,8 +6,8 @@
 #ifndef COMMON_UTIL_RANDOM
 #define COMMON_UTIL_RANDOM
 
-#include <random>
 #include <cstdint>
+#include <random>
 
 namespace cppnet {
 
@@ -24,6 +24,6 @@ private:
     std::uniform_int_distribution<int32_t> _uniform;
 };
 
-}
+} // namespace cppnet
 
 #endif

--- a/cppnet/cppnet.cpp
+++ b/cppnet/cppnet.cpp
@@ -5,13 +5,13 @@
 
 #include "include/cppnet.h"
 
-#include "cppnet_base.h"
 #include "cppnet/cppnet_config.h"
+#include "cppnet_base.h"
 
-#include "common/util/random.h"
-#include "common/log/log.h"
 #include "common/log/file_logger.h"
+#include "common/log/log.h"
 #include "common/log/stdout_logger.h"
+#include "common/util/random.h"
 
 namespace cppnet {
 

--- a/cppnet/cppnet_base.h
+++ b/cppnet/cppnet_base.h
@@ -6,9 +6,10 @@
 #ifndef CPPNET_CPPNET_BASE
 #define CPPNET_CPPNET_BASE
 
-#include <vector>
 #include <memory>
 #include <string>
+#include <vector>
+
 #include "include/cppnet_type.h"
 
 namespace cppnet {
@@ -68,5 +69,6 @@ private:
     std::vector<std::shared_ptr<Dispatcher>> _dispatchers;
 };
 
-}
+} // namespace cppnet
+
 #endif

--- a/include/cppnet.h
+++ b/include/cppnet.h
@@ -6,12 +6,12 @@
 #ifndef INCLUDE_CPPNET
 #define INCLUDE_CPPNET
 
-#include <string>
 #include <memory>
+#include <string>
 
-#include "cppnet_type.h"
 #include "cppnet_buffer.h"
 #include "cppnet_socket.h"
+#include "cppnet_type.h"
 
 namespace cppnet {
 
@@ -54,6 +54,6 @@ private:
     std::shared_ptr<CppNetBase> _cppnet_base;
 };
 
-}
+} // namespace cppnet
 
 #endif

--- a/include/cppnet_buffer.h
+++ b/include/cppnet_buffer.h
@@ -12,8 +12,8 @@ namespace cppnet {
 
 class Buffer {
 public:
-    Buffer() {}
-    virtual ~Buffer() {}
+    Buffer() = default;
+    virtual ~Buffer() = default;
 
     // read to data to buf but don't move the read point.
     // return read size.
@@ -45,6 +45,6 @@ public:
     virtual uint32_t FindStr(const char* s, uint32_t s_len) = 0;
 };
 
-}
+} // namespace cppnet
 
 #endif

--- a/include/cppnet_socket.h
+++ b/include/cppnet_socket.h
@@ -6,16 +6,16 @@
 #ifndef INCLUDE_CPPNET_SOCKET
 #define INCLUDE_CPPNET_SOCKET
 
-#include <string>
 #include <cstdint>
+#include <string>
 
 namespace cppnet {
 
 // cppnet socket interface
 class CNSocket {
 public:
-    CNSocket() {}
-    virtual ~CNSocket() {}
+    CNSocket() = default;
+    virtual ~CNSocket() = default;
     // get os native socket
     virtual uint64_t GetSocket() = 0;
     // get local listen port
@@ -40,6 +40,6 @@ public:
     virtual void* GetContext() = 0;
 };
 
-}
+} // namespace cppnet
 
 #endif

--- a/include/cppnet_type.h
+++ b/include/cppnet_type.h
@@ -6,35 +6,35 @@
 #ifndef INCLUDE_CPPNET_TYPE
 #define INCLUDE_CPPNET_TYPE
 
-#include <memory>
 #include <cstdint>
 #include <functional>
+#include <memory>
 
 namespace cppnet {
 
 // socket
 class Buffer;
 class CNSocket;
-typedef std::shared_ptr<CNSocket> Handle;
-typedef std::shared_ptr<Buffer>   BufferPtr;
+using Handle = std::shared_ptr<CNSocket>;
+using BufferPtr = std::shared_ptr<Buffer>;
 
 // call back define
 // param : param is set when call
-typedef std::function<void(Handle)>                     timer_call_back;
-typedef std::function<void(void*)>                      user_timer_call_back;
+using timer_call_back = std::function<void (Handle)>;
+using user_timer_call_back = std::function<void (void *)>;
 
 // handle : handle of socket
 // err    : error code
-typedef std::function<void(Handle, uint32_t)>           connect_call_back;
+using connect_call_back = std::function<void (Handle, uint32_t)>;
 
 // handle : handle of socket
 // len    : send date len
-typedef std::function<void(Handle, uint32_t)>           write_call_back;
+using write_call_back = std::function<void (Handle, uint32_t)>;
 
 // handle : handle of socket
 // data   : point to recv data buffer
 // len    : recv data len
-typedef std::function<void(Handle, BufferPtr,uint32_t)> read_call_back;
+using read_call_back = std::function<void (Handle, BufferPtr, uint32_t)>;
     
 // error code
 enum CPPNET_ERROR_CODE {
@@ -44,6 +44,6 @@ enum CPPNET_ERROR_CODE {
     CEC_CONNECT_REFUSE         = 3,    // remote refuse connect or server not exist.
 };
 
-}
+} // namespace cppnet
 
 #endif

--- a/test/echo/echo_client.cpp
+++ b/test/echo/echo_client.cpp
@@ -4,8 +4,8 @@
 #include <iostream>
 #include <algorithm> // for std::find
 
-#include "include/cppnet.h"
 #include "common/util/time.h"
+#include "include/cppnet.h"
 
 using namespace cppnet;
 


### PR DESCRIPTION
1. header sort
2. add =default for default constructor and destructor 
3. add namespace closing name 
4. use using instead of typedef