### PR TITLE
Fix submodule build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
 set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
 
 # include
-include_directories(${CMAKE_SOURCE_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 add_subdirectory(common)
 add_subdirectory(cppnet)

--- a/cppnet/event/epoll/epoll_action.cpp
+++ b/cppnet/event/epoll/epoll_action.cpp
@@ -50,7 +50,7 @@ EpollEventActions::EpollEventActions():
 }
 
 EpollEventActions::~EpollEventActions() {
-    if (_epoll_handler > 0) {
+    if (_epoll_handler != nullptr) {
 #ifdef __win__
         epoll_close(_epoll_handler);
 #else


### PR DESCRIPTION
I tried to use this library as submodule in my project(it uses mingw). With it I encountered 2 problems:
1) library tries to add root(parent's root if it is submodule) directory to include_directories and hence it cannot find some includes because include_directories point to wrong directory
2) pointer comparison using less sign

With this PR I try to solve both issues